### PR TITLE
Fix image prompting

### DIFF
--- a/src/components/Canvas.tsx
+++ b/src/components/Canvas.tsx
@@ -42,8 +42,6 @@ function Canvas({ setCurIndex }: { setCurIndex: Dispatch<any> }) {
   const { onClose, onOpen, isOpen } = useDisclosure();
 
   const handleChange = (color, event) => {
-    console.log("color");
-    console.log(color.hex);
     setColor(color.hex);
   };
 
@@ -81,7 +79,7 @@ function Canvas({ setCurIndex }: { setCurIndex: Dispatch<any> }) {
           <br></br>
           <StyledButton
             onClick={() => {
-              console.log(canvasRef.current.getDataURL());
+              // console.log(canvasRef.current.getDataURL());
               setDataURL(canvasRef.current.getDataURL());
               generateImage.mutate({
                 imagePath: canvasRef.current.getDataURL(),

--- a/src/components/Canvas.tsx
+++ b/src/components/Canvas.tsx
@@ -79,11 +79,13 @@ function Canvas({ setCurIndex }: { setCurIndex: Dispatch<any> }) {
           <br></br>
           <StyledButton
             onClick={() => {
-              // console.log(canvasRef.current.getDataURL());
-              setDataURL(canvasRef.current.getDataURL());
-              generateImage.mutate({
-                imagePath: canvasRef.current.getDataURL(),
-              });
+              if (canvasRef.current) {
+                const dataURL = canvasRef.current.getDataURL();
+                setDataURL(dataURL);
+                generateImage.mutate({
+                  imagePath: dataURL,
+                });
+              }
               onOpen();
             }}
             label={"Generate an Image"}

--- a/src/server/api/routers/gpt.ts
+++ b/src/server/api/routers/gpt.ts
@@ -183,7 +183,7 @@ export const gptRouter = createTRPCRouter({
         model: "dall-e-3",
         prompt: imgPrompt + " Make it simplistic cartoon style and for kids.",
         n: 1,
-        size: "512x512",
+        size: "1024x1024",
       });
 
       return img.data;

--- a/src/server/api/routers/gpt.ts
+++ b/src/server/api/routers/gpt.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck
 import { z } from "zod";
-import OpenAI from "openai";
+import OpenAI, { toFile } from "openai";
 import fs from "fs";
 import {
   DetectDocumentTextCommand,
@@ -147,26 +147,21 @@ export const gptRouter = createTRPCRouter({
     .mutation(async ({ input }) => {
       const regex = /^data:.+\/(.+);base64,(.*)$/;
       const matches = input.imagePath.match(regex);
-      const ext = matches[1];
       const data = matches[2];
       const buffer = Buffer.from(data, "base64");
-      const filePath = "./public/assets/drawing." + ext;
-      fs.writeFileSync(filePath, buffer);
+
+      buffer.name = "image.png";
+
+      const file = await toFile(buffer);
 
       const res = await openai.images.edit({
-        image: fs.createReadStream(filePath),
+        image: file,
         prompt:
           "Fill in empty spaces with bright polka dots related to the art style given",
         n: 1,
         size: "1024x1024",
       });
 
-      // Cast the ReadStream to `any` to appease the TypeScript compiler
-      // const image = await openai.images.createVariation({
-      //   image: fs.createReadStream(filePath),
-      // });
-
-      // return image.data;
       return res.data;
     }),
   /**


### PR DESCRIPTION
This PR changes the flow for image generation by making two API calls: 
1. Image-to-text using `create` function from OpenAI
2. Text-to-Image using `generate` function from OpenAI

Cut costs on API calls by:
- Limiting output tokens to 100 in `create` call
- Providing image of `low` detail resolution in `create` call
- Generating smallest possible image size in `generate` call

Room for improvement in future: 
- Try to reduce prompts to use even fewer tokens
- Speed up API call process somehow (maybe faster to save images to S3 and retrieve than use OpenAI's `toFile`)

<img width="300" alt="PNG image" src="https://github.com/zorazrr/activ-card/assets/40867028/70ea573d-f155-4919-9423-16fdd2d8acc3">
<img width="300" alt="PNG image" src="https://github.com/zorazrr/activ-card/assets/40867028/a99107f9-e42a-4ebb-82d4-550a7178d76f">
<img width="300" alt="Screenshot 2024-02-25 at 8 21 19 PM" src="https://github.com/zorazrr/activ-card/assets/40867028/30f0e0ea-5e6f-4d19-aeb6-7a80293aeba0">

