### PR TITLE
Complete more styling todos

### DIFF
--- a/src/components/AudioRecorder.tsx
+++ b/src/components/AudioRecorder.tsx
@@ -42,14 +42,10 @@ const AudioRecorder = ({
   const startRecording = async () => {
     if (permission) {
       if (stream) {
-        console.log("Case 1");
-        console.log("Start recording");
         setRecordingStatus("recording");
         const media = new MediaRecorder(stream);
         mediaRecorder.current = media;
-        console.log(media.state);
         media.start();
-        console.log(media.state);
         const localAudioChunks: Blob[] = [];
         media.ondataavailable = (event) => {
           if (typeof event.data === "undefined") return;
@@ -57,17 +53,13 @@ const AudioRecorder = ({
           localAudioChunks.push(event.data);
         };
         setAudioChunks(localAudioChunks);
-        console.log("Recording started");
       } else {
         const streamData = await getMicrophonePermission();
         if (streamData) {
-          console.log("Case 2");
           setRecordingStatus("recording");
           const media = new MediaRecorder(streamData);
           mediaRecorder.current = media;
-          console.log(media.state);
           media.start();
-          console.log(media.state);
           const localAudioChunks: Blob[] = [];
           media.ondataavailable = (event) => {
             if (typeof event.data === "undefined") return;
@@ -75,19 +67,15 @@ const AudioRecorder = ({
             localAudioChunks.push(event.data);
           };
           setAudioChunks(localAudioChunks);
-          console.log("Recording started");
         }
       }
     } else {
-      console.log("Case 3");
       const streamData = await getMicrophonePermission();
       if (streamData) {
         setRecordingStatus("recording");
         const media = new MediaRecorder(streamData);
         mediaRecorder.current = media;
-        console.log(media.state);
         media.start();
-        console.log(media.state);
         const localAudioChunks: Blob[] = [];
         media.ondataavailable = (event) => {
           if (typeof event.data === "undefined") return;
@@ -95,7 +83,6 @@ const AudioRecorder = ({
           localAudioChunks.push(event.data);
         };
         setAudioChunks(localAudioChunks);
-        console.log("Recording started");
       }
     }
   };
@@ -111,7 +98,6 @@ const AudioRecorder = ({
   };
 
   const stopRecording = () => {
-    console.log("Stop recording");
     setRecordingStatus("inactive");
     mediaRecorder.current!.stop();
     mediaRecorder.current!.onstop = () => {
@@ -124,7 +110,6 @@ const AudioRecorder = ({
       setAudio(audioUrl);
       setAudioChunks([]);
     };
-    console.log("Recording stopped");
   };
 
   useEffect(() => {

--- a/src/components/AudioRecorder.tsx
+++ b/src/components/AudioRecorder.tsx
@@ -1,12 +1,20 @@
-import { useEffect, useRef, useState } from "react";
+import {
+  type Dispatch,
+  type SetStateAction,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import { api } from "~/utils/api";
 
 const AudioRecorder = ({
   textCallBack,
   shouldDisplayAnswer,
+  setIsProcessingRecordedAnswer,
 }: {
   textCallBack: (text: string) => void;
   shouldDisplayAnswer: boolean;
+  setIsProcessingRecordedAnswer: Dispatch<SetStateAction<boolean>>;
 }) => {
   const mimeType = "audio/mp3";
   const [permission, setPermission] = useState(false);
@@ -42,6 +50,7 @@ const AudioRecorder = ({
   const startRecording = async () => {
     if (permission) {
       if (stream) {
+        setIsProcessingRecordedAnswer(true);
         setRecordingStatus("recording");
         const media = new MediaRecorder(stream);
         mediaRecorder.current = media;

--- a/src/components/AudioRecorder.tsx
+++ b/src/components/AudioRecorder.tsx
@@ -3,8 +3,10 @@ import { api } from "~/utils/api";
 
 const AudioRecorder = ({
   textCallBack,
+  shouldDisplayAnswer,
 }: {
   textCallBack: (text: string) => void;
+  shouldDisplayAnswer: boolean;
 }) => {
   const mimeType = "audio/mp3";
   const [permission, setPermission] = useState(false);
@@ -137,6 +139,7 @@ const AudioRecorder = ({
         <button
           onClick={() => startRecording()}
           className="h-fit w-fit rounded-lg bg-mediumBlue px-6 py-1 text-sm text-white"
+          disabled={shouldDisplayAnswer}
         >
           Speak
         </button>

--- a/src/components/Canvas.tsx
+++ b/src/components/Canvas.tsx
@@ -6,29 +6,30 @@ import { VStack, useDisclosure } from "@chakra-ui/react";
 import { type Image } from "openai/resources/images.mjs";
 import { api } from "~/utils/api";
 import StyledButton from "./Button";
-import StyledModal from "./StyledModal";
 import ImageModal from "./ImageModal";
 import Countdown from "./Countdown";
 
 const colors = [
-  "#f44336",
-  "#e91e63",
-  "#9c27b0",
-  "#673ab7",
-  "#3f51b5",
-  "#2196f3",
-  "#03a9f4",
-  "#00bcd4",
-  "#009688",
-  "#4caf50",
-  "#8bc34a",
-  "#cddc39",
-  "#ffeb3b",
-  "#ffc107",
-  "#ff9800",
-  "#ffffff",
-  "#795548",
-  "#607d8b",
+  "#ff1100",
+  // "#f44336", // Red
+  "#e57373", // Light Red
+  "#ff9800", // Orange
+  "#ffc107", // Amber
+  "#ffeb3b", // Yellow
+  "#4caf50", // Green
+  "#8bc34a", // Light Green
+  // "#cddc39", // Lime (Yellowish Green)
+  "#00bcd4", // Cyan
+  "#2196f3", // Blue
+  "#f263ed",
+  "#e91e63", // Pink
+  "#9c27b0", // Purple
+  "#673ab7", // Deep Purple
+  "#3f51b5", // Indigo
+  "#000000", // Black
+  "#ffffff", // White
+  "#607d8b", // Blue Grey
+  "#795548", // Brown
 ];
 
 function Canvas({

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -47,7 +47,7 @@ const SetCard = (props: SetCardProps) => {
       p={3}
       borderRadius="10"
       onClick={onCardClick}
-      backgroundColor="#4A729D"
+      backgroundColor="mediumBlue.500"
       color="white"
       style={{ cursor: "pointer" }}
       marginRight={5}

--- a/src/components/Flashcard.tsx
+++ b/src/components/Flashcard.tsx
@@ -8,7 +8,7 @@ import {
 } from "react";
 import { api } from "~/utils/api";
 import AudioRecorder from "./AudioRecorder";
-import { Spinner, Textarea } from "@chakra-ui/react";
+import { Spinner, Stack, Textarea } from "@chakra-ui/react";
 
 interface FlashCardProps {
   card: Card;
@@ -39,6 +39,8 @@ const FlashCard: FC<FlashCardProps> = ({
   const [studentAudioText, setStudentAudioText] = useState<string>();
   const [answerExplanation, setAnswerExplanation] = useState<string>("");
   const [shouldDisplayAnswer, setShouldDisplayAnswer] = useState(false);
+  const [isProcessingRecordedAnswer, setIsProcessingRecordedAnswer] =
+    useState(false);
   const checkAnswerMutation = api.gpt.checkAnswer.useMutation({ retry: false });
   const explainAnswerMutation = api.gpt.explainAnswer.useMutation({
     retry: false,
@@ -147,6 +149,7 @@ const FlashCard: FC<FlashCardProps> = ({
   useEffect(() => {
     if (studentAudioText !== undefined) {
       checkAnswer();
+      setIsProcessingRecordedAnswer(false);
       setStudentInput(studentAudioText);
       setStudentAudioText(undefined);
     }
@@ -159,18 +162,31 @@ const FlashCard: FC<FlashCardProps> = ({
           <p>{card.term}</p>
         </div>
         <div className="flex h-full w-full flex-col gap-2">
-          <Textarea
-            h="full"
-            value={studentInput}
-            onChange={(e) => setStudentInput(e.target.value)}
-            onKeyDown={handleKeyPress}
-            onKeyUp={handleKeyUp}
-            placeholder="Start typing or press icon to speak."
-          />
+          {isProcessingRecordedAnswer ? (
+            <Stack
+              h="full"
+              justifyContent="center"
+              alignItems="center"
+              borderRadius="md"
+              border="1px lightgray solid"
+            >
+              <Spinner />
+            </Stack>
+          ) : (
+            <Textarea
+              h="full"
+              value={studentInput}
+              onChange={(e) => setStudentInput(e.target.value)}
+              onKeyDown={handleKeyPress}
+              onKeyUp={handleKeyUp}
+              placeholder="Start typing or press icon to speak."
+            />
+          )}
           <div className="flex w-full flex-row justify-between">
             <AudioRecorder
               textCallBack={setStudentAudioText}
               shouldDisplayAnswer={shouldDisplayAnswer}
+              setIsProcessingRecordedAnswer={setIsProcessingRecordedAnswer}
             />
             <div className="flex flex-row gap-x-3">
               <button

--- a/src/components/Flashcard.tsx
+++ b/src/components/Flashcard.tsx
@@ -168,7 +168,10 @@ const FlashCard: FC<FlashCardProps> = ({
             placeholder="Start typing or press icon to speak."
           />
           <div className="flex w-full flex-row justify-between">
-            <AudioRecorder textCallBack={setStudentAudioText} />
+            <AudioRecorder
+              textCallBack={setStudentAudioText}
+              shouldDisplayAnswer={shouldDisplayAnswer}
+            />
             <div className="flex flex-row gap-x-3">
               <button
                 onClick={() => setShouldDisplayAnswer(true)}

--- a/src/components/Flashcard.tsx
+++ b/src/components/Flashcard.tsx
@@ -129,6 +129,21 @@ const FlashCard: FC<FlashCardProps> = ({
     }
   };
 
+  const handleKeyPress = (e) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      checkAnswer();
+    }
+  };
+
+  function handleKeyUp(e) {
+    //key code for enter
+    if (e.key === "Enter") {
+      e.preventDefault();
+      e.target.blur();
+    }
+  }
+
   useEffect(() => {
     if (studentAudioText !== undefined) {
       checkAnswer();
@@ -148,6 +163,8 @@ const FlashCard: FC<FlashCardProps> = ({
             h="full"
             value={studentInput}
             onChange={(e) => setStudentInput(e.target.value)}
+            onKeyDown={handleKeyPress}
+            onKeyUp={handleKeyUp}
             placeholder="Start typing or press icon to speak."
           />
           <div className="flex w-full flex-row justify-between">

--- a/src/components/ImageModal.tsx
+++ b/src/components/ImageModal.tsx
@@ -9,7 +9,7 @@ import {
   Button,
   Flex, // Use Flex instead of Box for layout control
 } from "@chakra-ui/react";
-import { Badge, Role } from "@prisma/client";
+import { type Badge, Role } from "@prisma/client";
 import NextImage from "next/image";
 
 import { type Image } from "openai/resources/images.mjs";
@@ -35,6 +35,7 @@ const ImageModal = ({
     },
   });
   const [fileName, setFileName] = useState<string>("test");
+  const [isSaved, setIsSaved] = useState(false);
 
   const uploadUrl = api.gpt.getPresignedUrl.useQuery(
     { fileName: fileName },
@@ -46,7 +47,7 @@ const ImageModal = ({
       const urlResponse = await uploadUrl.refetch();
       const presignedUrl = urlResponse.data!;
 
-      if (images && images[0]) {
+      if (images?.[0]) {
         saveBadge.mutate({
           genImageURL: images[0].url!,
           presignedURL: presignedUrl,
@@ -83,7 +84,7 @@ const ImageModal = ({
           justifyContent="center" // Center children vertically
           alignItems="center" // Center children horizontally
         >
-          {images && images[0]?.url ? (
+          {images?.[0]?.url ? (
             <>
               <NextImage
                 src={images[0].url}
@@ -98,13 +99,21 @@ const ImageModal = ({
               />
               {session && session.user.role == Role.STUDENT && (
                 <div style={{ paddingBottom: "2.5vh" }}>
-                  <StyledButton
-                    label="Save It"
+                  <Button
+                    isLoading={isSaved}
+                    backgroundColor="mediumBlue.500"
+                    textColor="white"
                     onClick={() => {
+                      setIsSaved(true);
                       setFileName(`uploads/${Date.now()}_${session.user.id}`);
                     }}
-                    colorInd={1}
-                  ></StyledButton>
+                    py={2}
+                    borderRadius="md"
+                    _hover={{ opacity: "75%" }}
+                    w="8rem"
+                  >
+                    Save It
+                  </Button>
                 </div>
               )}
             </>

--- a/src/components/Progress/ProgressBar.tsx
+++ b/src/components/Progress/ProgressBar.tsx
@@ -3,17 +3,21 @@ import { Progress } from "@chakra-ui/react";
 const ProgressBar = ({
   percentage,
   shouldApplyMargin = false,
+  width,
+  shouldApplyBorderRadius,
 }: {
   percentage: number;
   shouldApplyMargin?: boolean;
+  width?: number;
+  shouldApplyBorderRadius?: boolean;
 }) => (
   <Progress
     margin={shouldApplyMargin ? "auto" : "inherit"}
-    w="60%"
+    w={width ? `${width}%` : "60%"}
     colorScheme="darkBlue"
     height="28px"
     value={percentage}
-    borderRadius={10}
+    borderRadius={shouldApplyBorderRadius ? 10 : 0}
   />
 );
 

--- a/src/components/SideBar/ClassRadioButton.tsx
+++ b/src/components/SideBar/ClassRadioButton.tsx
@@ -39,14 +39,14 @@ const ClassRadioButton = ({
         color="white"
         h="100%"
         _checked={{
-          bg: "#4A729D",
+          bg: "mediumBlue.500",
           color: "white",
-          borderBottom: "0.1vh solid #1A3F67",
+          borderBottom: "0.1vh solid darkBlue.500",
         }}
         _hover={{
-          bg: "#4A729D",
+          bg: "mediumBlue.500",
           color: "white",
-          borderBottom: "0.1vh solid #1A3F67",
+          borderBottom: "0.1vh solid darkBlue.500",
         }}
         px={5}
         py={3}

--- a/src/components/SideBar/SideBar.tsx
+++ b/src/components/SideBar/SideBar.tsx
@@ -121,7 +121,7 @@ const Sidebar = ({
               color="white"
               aria-label="Add card"
               icon={<AddIcon color="white" />}
-              _hover={{ bg: "#88ADD5", borderColor: "#88ADD5" }}
+              _hover={{ bg: "midBlue.500", borderColor: "midBlue.500" }}
               onClick={onAddClass}
             />
           </VStack>
@@ -137,7 +137,7 @@ const Sidebar = ({
               aria-label="Add card"
               fontSize="20px"
               icon={<AddIcon color="white" />} // Apply color directly to the icon
-              _hover={{ bg: "#88ADD5", borderColor: "#88ADD5" }}
+              _hover={{ bg: "midBlue.500", borderColor: "midBlue.500" }}
               onClick={onAddClass}
             />
             <Text className={"h5"} color="white">
@@ -149,7 +149,7 @@ const Sidebar = ({
       </Box>
 
       <HStack alignItems={"center"} mb={3} ml={"1.25rem"}>
-        {session && session.user.image && (
+        {session?.user.image && (
           <ChakImage
             borderRadius="full"
             src={session?.user.image}

--- a/src/pages/set/[id].tsx
+++ b/src/pages/set/[id].tsx
@@ -8,6 +8,7 @@ import Canvas from "~/components/Canvas";
 import { type Card } from "@prisma/client";
 import ProgressBar from "~/components/Progress/ProgressBar";
 import Image from "next/image";
+import _ from "lodash";
 
 const Set = ({
   tempIdx,
@@ -77,7 +78,13 @@ const Set = ({
     });
 
     toast({
-      title: "That is correct!",
+      title: _.sample([
+        "Nice work!",
+        "Amazing Job!",
+        "Way to go!",
+        "Show em' how it's done!",
+        "You got brains!",
+      ]),
       status: "success",
       duration: 3000,
       isClosable: false,
@@ -87,7 +94,13 @@ const Set = ({
 
   const handleIncorrectAnswer = () => {
     toast({
-      title: "Try again!",
+      title: _.sample([
+        "Try again!",
+        "You've got this!",
+        "So close!",
+        "Keep going!",
+        "Practice makes perfect!",
+      ]),
       status: "error",
       duration: 3000,
       isClosable: false,
@@ -113,15 +126,6 @@ const Set = ({
       ) : (
         <>
           <p className="w-full pl-8 pt-8 text-center font-bold">
-            {/* <Icon
-              as={MdHome}
-              position="absolute"
-              left={5}
-              boxSize={6}
-              onClick={navigateHome}
-              _hover={{ boxShadow: "5px", opacity: "75%", cursor: "pointer" }}
-            /> */}
-
             <HStack gap={0} position="absolute" onClick={navigateHome}>
               <div className="hover:opacity-75">
                 <Link href="/dashboard" className="flex flex-col 2xl:flex-row">

--- a/src/pages/set/[id].tsx
+++ b/src/pages/set/[id].tsx
@@ -119,6 +119,7 @@ const Set = ({
               left={5}
               boxSize={6}
               onClick={navigateHome}
+              _hover={{ boxShadow: "5px", opacity: "75%", cursor: "pointer" }}
             />
             {set.name}
           </p>

--- a/src/pages/set/[id].tsx
+++ b/src/pages/set/[id].tsx
@@ -2,24 +2,12 @@ import { useEffect, useState } from "react"; // Import useState hook
 import { useRouter } from "next/router";
 import FlashCard from "~/components/Flashcard";
 import { api } from "~/utils/api";
-import {
-  HStack,
-  Icon,
-  Spinner,
-  Tooltip,
-  VStack,
-  useToast,
-} from "@chakra-ui/react";
+import { Icon, Spinner, Stack, useToast } from "@chakra-ui/react";
 import { MdHome } from "react-icons/md";
-import {
-  ChevronLeftIcon,
-  ChevronRightIcon,
-  InfoOutlineIcon,
-} from "@chakra-ui/icons";
+import { ChevronLeftIcon, ChevronRightIcon } from "@chakra-ui/icons";
 import Canvas from "~/components/Canvas";
 import { type Card } from "@prisma/client";
 import ProgressBar from "~/components/Progress/ProgressBar";
-import StyledButton from "~/components/Button";
 
 const Set = ({
   tempIdx,
@@ -52,7 +40,11 @@ const Set = ({
   }, [cards]);
 
   if (!cards || !set) {
-    return <Spinner />;
+    return (
+      <Stack h="100%" w="100%" justifyContent="center" alignItems="center">
+        <Spinner />
+      </Stack>
+    );
   }
 
   const moveCurrentCardToEnd = () => {

--- a/src/pages/set/[id].tsx
+++ b/src/pages/set/[id].tsx
@@ -2,12 +2,12 @@ import { useEffect, useState } from "react"; // Import useState hook
 import { useRouter } from "next/router";
 import FlashCard from "~/components/Flashcard";
 import { api } from "~/utils/api";
-import { Icon, Spinner, Stack, useToast } from "@chakra-ui/react";
-import { MdHome } from "react-icons/md";
+import { HStack, Icon, Link, Spinner, Stack, useToast } from "@chakra-ui/react";
 import { ChevronLeftIcon, ChevronRightIcon } from "@chakra-ui/icons";
 import Canvas from "~/components/Canvas";
 import { type Card } from "@prisma/client";
 import ProgressBar from "~/components/Progress/ProgressBar";
+import Image from "next/image";
 
 const Set = ({
   tempIdx,
@@ -112,15 +112,28 @@ const Set = ({
         <Canvas setShowCanvas={setShowCanvas} setId={setId as string} />
       ) : (
         <>
-          <p className="w-full pb-16 pt-8 text-center font-bold">
-            <Icon
+          <p className="w-full pl-8 pt-8 text-center font-bold">
+            {/* <Icon
               as={MdHome}
               position="absolute"
               left={5}
               boxSize={6}
               onClick={navigateHome}
               _hover={{ boxShadow: "5px", opacity: "75%", cursor: "pointer" }}
-            />
+            /> */}
+
+            <HStack gap={0} position="absolute" onClick={navigateHome}>
+              <div className="hover:opacity-75">
+                <Link href="/dashboard" className="flex flex-col 2xl:flex-row">
+                  <Image
+                    src="/assets/logo.png"
+                    alt="header"
+                    width={60}
+                    height={60}
+                  />
+                </Link>
+              </div>
+            </HStack>
             {set.name}
           </p>
           {curIndex >= 0 &&

--- a/src/pages/set/[id].tsx
+++ b/src/pages/set/[id].tsx
@@ -135,10 +135,6 @@ const Set = ({
           curIndex < flashcards.length &&
           flashcards[curIndex] ? (
             <>
-              <ProgressBar
-                percentage={(100 * maxIndex) / cards.length}
-                shouldApplyMargin={true}
-              />
               <FlashCard
                 key={flashcards[curIndex]!.id}
                 card={flashcards[curIndex]!}
@@ -204,6 +200,14 @@ const Set = ({
               </button>
             </div>
           </div>
+          {curIndex !== flashcards?.length && (
+            <ProgressBar
+              percentage={(100 * maxIndex) / cards.length}
+              shouldApplyMargin={true}
+              width={100}
+              shouldApplyBorderRadius={false}
+            />
+          )}
         </>
       )}
     </div>


### PR DESCRIPTION
Completes the following todo's for styling

**Overall**
- [x]  Use Chakra Theme everywhere

**Badge Component**
- [x]  Add spinner after save is selected

** On Canvas**
- [x]  Add better colors

**Toast Component on Study Mode**
- [x]  Give encouraging compliments when they get it right
- [x]  When they get it wrong also like "so close"
- [x]  Style home button at the top (use logo with Home)

 ** On Set Study**
- [x]  Spinner should be centered
- [x]  Move progress bar to bottom
- [x]  Clicking enter when studying should automatically submit it
- [x]  Can still record and re-do their answers after they get them wrong because audio button is not disabled (behaviors for when they get wrong or dk, should disable from submitting again only like click got it or like auto flip (us) the card and see the answer)
- [x]  Some kind of loader while it's processing or capturing answer (especially for long answers) or should show the words as they speak.